### PR TITLE
[Fuzzing] Modifying code to be fuzzeable and implementing fuzz target

### DIFF
--- a/include/pci_handler.hpp
+++ b/include/pci_handler.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -22,6 +23,7 @@ class PciDataHandler : public DataInterface
   public:
     explicit PciDataHandler(uint32_t regionAddress, size_t regionSize,
                             std::unique_ptr<stdplus::fd::Fd> fd);
+    explicit PciDataHandler(uint8_t *data_ptr, size_t regionSize);
 
     std::vector<uint8_t> read(uint32_t offset, uint32_t length) override;
     uint32_t write(const uint32_t offset,
@@ -32,7 +34,8 @@ class PciDataHandler : public DataInterface
     uint32_t regionSize;
 
     std::unique_ptr<stdplus::fd::Fd> fd;
-    stdplus::fd::MMap mmap;
+    std::optional<stdplus::fd::MMap> mmap;
+    uint8_t *data_ptr;
 };
 
 } // namespace bios_bmc_smm_error_logger

--- a/include/read_loop.hpp
+++ b/include/read_loop.hpp
@@ -1,0 +1,15 @@
+#pragma once  // Ensures the file is only included once per translation unit
+
+#include "buffer.hpp"
+#include "rde/rde_handler.hpp"
+
+#include <boost/asio.hpp>
+
+#include <memory>
+
+namespace bios_bmc_smm_error_logger {
+    void readLoop(boost::asio::steady_timer* t,
+        const std::shared_ptr<BufferInterface>& bufferInterface,
+        const std::shared_ptr<rde::RdeCommandHandler>& rdeCommandHandler,
+        const boost::system::error_code& error);
+}

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,5 @@
 option('tests', type: 'feature', value: 'enabled', description: 'Build tests')
+option('fuzzing', type : 'boolean', value : false, description : 'Enable building the fuzzer.')
 
 # Timer constant
 option(

--- a/src/fuzzer.cpp
+++ b/src/fuzzer.cpp
@@ -1,0 +1,86 @@
+#include "config.h"
+
+#include "buffer.hpp"
+#include "pci_handler.hpp"
+#include "rde/external_storer_file.hpp"
+#include "rde/external_storer_interface.hpp"
+#include "rde/rde_handler.hpp"
+#include "read_loop.hpp" 
+
+#include <boost/asio.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+
+#include <chrono>
+#include <memory>
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace bios_bmc_smm_error_logger;
+
+namespace
+{
+constexpr std::chrono::milliseconds readIntervalinMs(READ_INTERVAL_MS);
+constexpr std::size_t memoryRegionSize = MEMORY_REGION_SIZE;
+constexpr uint32_t bmcInterfaceVersion = BMC_INTERFACE_VERSION;
+constexpr uint16_t queueSize = QUEUE_REGION_SIZE;
+constexpr uint16_t ueRegionSize = UE_REGION_SIZE;
+static constexpr std::array<uint32_t, 4> magicNumber = {
+    MAGIC_NUMBER_BYTE1, MAGIC_NUMBER_BYTE2, MAGIC_NUMBER_BYTE3,
+    MAGIC_NUMBER_BYTE4};
+
+// Global state variables
+static bool isInitialized = false;
+static std::vector<uint8_t> buffer;
+static std::shared_ptr<BufferInterface> bufferHandler;
+static std::shared_ptr<rde::RdeCommandHandler> rdeCommandHandler;
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    if (!isInitialized) {
+        buffer.resize(memoryRegionSize);
+        
+        boost::asio::io_context io;
+        boost::asio::steady_timer t(io, readIntervalinMs); // ignored for fuzzing
+    
+        // bufferHandler initialization
+        std::unique_ptr<DataInterface> pciDataHandler =
+           std::make_unique<PciDataHandler>(buffer.data(), memoryRegionSize);
+        bufferHandler = std::make_shared<BufferImpl>(std::move(pciDataHandler));
+ 
+        // rdeCommandHandler initialization
+        std::shared_ptr<sdbusplus::asio::connection> conn =
+            std::make_shared<sdbusplus::asio::connection>(io);
+        conn->request_name("xyz.openbmc_project.bios_bmc_smm_error_logger");
+    
+        std::unique_ptr<rde::FileHandlerInterface> fileIface =
+            std::make_unique<rde::ExternalStorerFileWriter>();
+        std::unique_ptr<rde::ExternalStorerInterface> exFileIface =
+            std::make_unique<rde::ExternalStorerFileInterface>(
+                conn, "/run/bmcweb", std::move(fileIface));
+
+        rdeCommandHandler =
+            std::make_unique<rde::RdeCommandHandler>(std::move(exFileIface));
+
+        bufferHandler->initialize(bmcInterfaceVersion, queueSize, ueRegionSize,
+                              magicNumber);
+        isInitialized = true;
+    }
+
+    std::fill(buffer.begin(), buffer.end(), 0);
+    std::copy(Data, Data + std::min(Size, buffer.size()), buffer.begin());
+    
+    try {
+        boost::system::error_code ec;
+        bios_bmc_smm_error_logger::readLoop(
+          static_cast<boost::asio::basic_waitable_timer<std::chrono::_V2::steady_clock>*>(nullptr),
+          bufferHandler, 
+          rdeCommandHandler, 
+          ec
+        );
+    } catch (const std::runtime_error& e) {
+        std::cout << "Caught std::runtime_error (ignored by fuzzer): " << e.what() << std::endl;
+    }
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,19 +5,14 @@
 #include "rde/external_storer_file.hpp"
 #include "rde/external_storer_interface.hpp"
 #include "rde/rde_handler.hpp"
+#include "read_loop.hpp"
 
 #include <boost/asio.hpp>
-#include <boost/endian/conversion.hpp>
 #include <sdbusplus/asio/object_server.hpp>
 #include <stdplus/fd/create.hpp>
-#include <stdplus/fd/impl.hpp>
 #include <stdplus/fd/managed.hpp>
-#include <stdplus/print.hpp>
 
 #include <chrono>
-#include <filesystem>
-#include <format>
-#include <fstream>
 #include <functional>
 #include <memory>
 
@@ -35,38 +30,6 @@ static constexpr std::array<uint32_t, 4> magicNumber = {
 } // namespace
 
 using namespace bios_bmc_smm_error_logger;
-
-void readLoop(boost::asio::steady_timer* t,
-              const std::shared_ptr<BufferInterface>& bufferInterface,
-              const std::shared_ptr<rde::RdeCommandHandler>& rdeCommandHandler,
-              const boost::system::error_code& error)
-{
-    if (error)
-    {
-        stdplus::print(stderr, "Async wait failed {}\n", error.message());
-        return;
-    }
-    std::vector<EntryPair> entryPairs = bufferInterface->readErrorLogs();
-    for (const auto& [entryHeader, entry] : entryPairs)
-    {
-        rde::RdeDecodeStatus rdeDecodeStatus =
-            rdeCommandHandler->decodeRdeCommand(
-                entry,
-                static_cast<rde::RdeCommandType>(entryHeader.rdeCommandType));
-        if (rdeDecodeStatus == rde::RdeDecodeStatus::RdeStopFlagReceived)
-        {
-            auto bufferHeader = bufferInterface->getCachedBufferHeader();
-            auto newbmcFlags =
-                boost::endian::little_to_native(bufferHeader.bmcFlags) |
-                static_cast<uint32_t>(BmcFlags::ready);
-            bufferInterface->updateBmcFlags(newbmcFlags);
-        }
-    }
-
-    t->expires_from_now(readIntervalinMs);
-    t->async_wait(
-        std::bind_front(readLoop, t, bufferInterface, rdeCommandHandler));
-}
 
 int main()
 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,12 +16,33 @@ bios_bmc_smm_error_logger_dep = declare_dependency(
     dependencies: bios_bmc_smm_error_logger_pre,
 )
 
+libfuzzer_args = [
+  '-fsanitize=fuzzer,address',  # Add 'undefined' or 'memory' if needed
+  '-fno-omit-frame-pointer',
+  '-g'
+]
+
+libfuzzer_dep = declare_dependency(
+  compile_args: libfuzzer_args,
+  link_args: libfuzzer_args
+)
+
+exe_sources = ['read_loop.cpp']
+exe_dependencies = [bios_bmc_smm_error_logger_dep, rde_dep]
+
+if get_option('fuzzing')
+  exe_sources += ['fuzzer.cpp']
+  exe_dependencies += [libfuzzer_dep]
+else
+  exe_sources += ['main.cpp']
+endif
+
 executable(
     'bios-bmc-smm-error-logger',
-    'main.cpp',
+    exe_sources,
     conf_h,
     implicit_include_directories: false,
-    dependencies: [bios_bmc_smm_error_logger_dep, rde_dep],
+    dependencies: exe_dependencies,
     install: true,
     install_dir: get_option('bindir'),
 )

--- a/src/read_loop.cpp
+++ b/src/read_loop.cpp
@@ -1,0 +1,50 @@
+#include "config.h"
+
+#include "buffer.hpp"
+#include "rde/rde_handler.hpp"
+
+#include <boost/asio.hpp>
+#include <boost/endian/conversion.hpp>
+#include <stdplus/print.hpp>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+
+
+namespace bios_bmc_smm_error_logger {
+    constexpr std::chrono::milliseconds readIntervalinMs(READ_INTERVAL_MS);
+    void readLoop(boost::asio::steady_timer* t,
+        const std::shared_ptr<BufferInterface>& bufferInterface,
+        const std::shared_ptr<rde::RdeCommandHandler>& rdeCommandHandler,
+        const boost::system::error_code& error)
+        {
+        if (error)
+        {
+            stdplus::print(stderr, "Async wait failed {}\n", error.message());
+            return;
+        }
+        std::vector<EntryPair> entryPairs = bufferInterface->readErrorLogs();
+        for (const auto& [entryHeader, entry] : entryPairs)
+        {
+            rde::RdeDecodeStatus rdeDecodeStatus =
+            rdeCommandHandler->decodeRdeCommand(
+                entry,
+                static_cast<rde::RdeCommandType>(entryHeader.rdeCommandType));
+            if (rdeDecodeStatus == rde::RdeDecodeStatus::RdeStopFlagReceived)
+            {
+                auto bufferHeader = bufferInterface->getCachedBufferHeader();
+                auto newbmcFlags =
+                    boost::endian::little_to_native(bufferHeader.bmcFlags) |
+                    static_cast<uint32_t>(BmcFlags::ready);
+                bufferInterface->updateBmcFlags(newbmcFlags);
+            }
+        }
+
+        if (t != nullptr) {
+            t->expires_from_now(readIntervalinMs);
+            t->async_wait(
+            std::bind_front(readLoop, t, bufferInterface, rdeCommandHandler));
+        }
+    }
+}


### PR DESCRIPTION
This PR allow us to fuzz it with LibFuzzer. For achieving it, we needed to make several modifications:

* Removed the `read_loop` funcionality from main file. We needed to do that to make the function to be called by diffferent "mains".
* Created a new contructor for PciDataHandler. We needed to do that to make possible the data be passed by an argument for the class and not getting it from /dev/mem as ir work for the original flow.
* Created a new file `fuzzer.cpp` for defining the fuzz target for it. We created the function `LLVMFuzzerTestOneInput` as it's expected by LibFuzzer, defining the behavior to pass the inputs to the `read_loop` function. https://llvm.org/docs/LibFuzzer.html#fuzz-target
* Modified read_loop logic to only call it self recursively if a timer is set. We needed to do that, as we need to call read loop just once for each iteration made by LibFuzzer.
* Created a flag `fuzzer` for the meson build. We managed to check this flag and pass the right parameters for building the project to be fuzzed. The default keeps the same, buiding it for running the main.

How to build for fuzzing:

* There's the commands used for building it for fuzzing:
```
CC=clang-18 CXX=clang++-18 meson setup build -Dtests=disabled -Dcpp_std=c++23 -Dread-interval-ms=10000 -Dmemory-region-size=1048576 -Dmemory-region-offset=3220176896 -Dbmc-interface-version=3 -Dqueue-region-size=16384 -Due-region-size=768 -Dmagic-number-byte1=2319403398 -Dmagic-number-byte2=1343703436 -Dmagic-number-byte3=2173375339 -Dmagic-number-byte4=3360702380 --buildtype=debug -Dfuzzing=true

ninja -C build
```
How did we test it:

* We managed to run it locally with the following commands:
```
# Creating an empty corpus
mkdir corpus
# We moved the stderr to /dev/null because we're logging and ignoring expected errors, and it avoids havign a dirty log
./build/src/bios-bmc-smm-error-logger corpus/ -max_len=1048576 2> /dev/null
```
* We also managed to build it for arm and run it inside of a emulated BMC instance.

What's next?
Once we have it merged, we will be able to onboard the project on https://github.com/google/oss-fuzz/. OSS-Fuzz is a project that onboards opensource projects to be fuzzed 24/7, providing a lot testcase management, as it runs inside of https://github.com/google/clusterfuzz. 

Also, we intend to have an instance of this fuzzer running inside of a emulated BMC instance, 24/7

Notes:
We're not expert on the business logic of the Bios Bmc Smm Error Logger, so we would be very important having a detailed review. We managed to test it well, but we're not sure if there is any edge cases that could be touched after the modifications. 

